### PR TITLE
Add Syntax Highlighting for Housify code

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,6 +1,14 @@
 {
     "version": "0.2",
     "language": "en",
-    "words": ["gusarich", "housify", "nextra", "hypixel", "respawns", "shiki", "rehype"],
+    "words": [
+        "gusarich",
+        "housify",
+        "nextra",
+        "hypixel",
+        "respawns",
+        "shiki",
+        "rehype"
+    ],
     "ignorePaths": ["node_modules/**", ".next/**", "out/**"]
 }

--- a/cspell.json
+++ b/cspell.json
@@ -1,6 +1,6 @@
 {
     "version": "0.2",
     "language": "en",
-    "words": ["gusarich", "housify", "nextra", "hypixel", "respawns"],
+    "words": ["gusarich", "housify", "nextra", "hypixel", "respawns", "shiki", "rehype"],
     "ignorePaths": ["node_modules/**", ".next/**", "out/**"]
 }

--- a/grammars/housify.tmLanguage.json
+++ b/grammars/housify.tmLanguage.json
@@ -1,0 +1,261 @@
+{
+    "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+    "name": "Housify",
+    "scopeName": "source.hsf",
+    "foldingStartMarker": "\\{\\s*$",
+    "foldingStopMarker": "^\\s*\\}",
+    "patterns": [
+        {
+            "include": "#handler"
+        },
+        {
+            "include": "#house"
+        },
+        {
+            "include": "#const"
+        },
+        {
+            "include": "#keywords"
+        },
+        {
+            "include": "#comment"
+        },
+        {
+            "include": "#literal"
+        },
+        {
+            "include": "#punctuation"
+        },
+        {
+            "include": "#expression"
+        },
+        {
+            "include": "#simple-type"
+        },
+        {
+            "include": "#variable"
+        }
+    ],
+    "repository": {
+        "keywords": {
+            "patterns": [
+                {
+                    "name": "keyword.control.housify",
+                    "match": "\\b(if|else)\\b"
+                },
+                {
+                    "comment": "Control flow keywords",
+                    "match": "\\b(if|else)\\b",
+                    "name": "keyword.control.housify"
+                },
+                {
+                    "match": "\\b(let)\\b",
+                    "name": "keyword.other.housify"
+                },
+                {
+                    "match": "\\b(handle)\\b",
+                    "name": "keyword.other.function.housify"
+                },
+                {
+                    "match": "\\b(house)\\b",
+                    "name": "keyword.other.struct.housify"
+                },
+                {
+                    "comment": "Stats modifiers",
+                    "match": "\\b(global|player)\\b(?!\\.)",
+                    "captures": {
+                        "0": {
+                            "name": "storage.modifier.housify"
+                        }
+                    }
+                },
+                {
+                    "comment": "Variable modifiers",
+                    "match": "\\b(const)\\b",
+                    "name": "storage.modifier.housify"
+                }
+            ]
+        },
+        "comment": {
+            "patterns": [
+                {
+                    "name": "comment.line.double-slash.housify",
+                    "begin": "//",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.comment.line.double-slash.housify"
+                        }
+                    },
+                    "end": "$"
+                },
+                {
+                    "name": "comment.block.housify",
+                    "begin": "\\s*/\\*",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "comment.block.begin.housify punctuation.definition.comment.begin.housify"
+                        }
+                    },
+                    "end": "\\*/",
+                    "endCaptures": {
+                        "0": {
+                            "name": "comment.block.end.housify punctuation.definition.comment.end.housify"
+                        }
+                    }
+                }
+            ]
+        },
+        "literal": {
+            "patterns": [
+                {
+                    "comment": "Decimal integer WITH leading zero",
+                    "match": "\\b(0[0-9]*)\\b",
+                    "name": "constant.numeric.decimal.housify"
+                },
+                {
+                    "comment": "Decimal integer WITHOUT leading zero",
+                    "match": "\\b([1-9](?:_?[0-9])*)\\b",
+                    "name": "constant.numeric.decimal.housify"
+                },
+                {
+                    "comment": "Boolean literal",
+                    "match": "\\b(true|false)\\b",
+                    "name": "constant.language.bool.housify"
+                },
+                {
+                    "comment": "Event",
+                    "match": "\\b(JOIN|QUIT|DEATH|KILL|RESPAWN|GROUP_CHANGE|PVP_STATE_CHANGE|FISH_CAUGHT|PORTAL_USE|DAMAGE|BLOCK_BREAK|PARKOUR_START|PARKOUR_FINISH|DROP_ITEM|PICKUP_ITEM|CHANGE_HELD_ITEM|TOGGLE_SNEAK|TOGGLE_FLIGHT)\\b",
+                    "name": "constant.language.other.housify entity.name.function.housify"
+                }
+            ]
+        },
+        "expression": {
+            "patterns": [
+                {
+                    "comment": "Logical operators",
+                    "match": "(\\|\\||&&)",
+                    "name": "keyword.operator.logical.housify"
+                },
+                {
+                    "comment": "Arithmetic operators",
+                    "match": "([+*\\-])|(/(?!/))",
+                    "name": "keyword.operator.arithmetic.housify"
+                },
+                {
+                    "comment": "Assignment operator",
+                    "match": "(?<![<>])=(?!=)",
+                    "name": "keyword.operator.assignment.equal.housify"
+                },
+                {
+                    "comment": "Comparison operators",
+                    "match": "([!=]=|<=?|>=?)",
+                    "name": "keyword.operator.comparison.housify"
+                }
+            ]
+        },
+        "punctuation": {
+            "patterns": [
+                {
+                    "match": ",",
+                    "name": "punctuation.comma.housify"
+                },
+                {
+                    "match": "[{}]",
+                    "name": "punctuation.brackets.curly.housify"
+                },
+                {
+                    "match": "[()]",
+                    "name": "punctuation.brackets.round.housify"
+                },
+                {
+                    "match": ";",
+                    "name": "punctuation.semi.housify"
+                },
+                {
+                    "match": ":",
+                    "name": "punctuation.colon.housify"
+                },
+                {
+                    "match": "\\.",
+                    "name": "punctuation.dot.housify"
+                }
+            ]
+        },
+        "simple-type": {
+            "comment": "Simple types",
+            "match": "\\b(int|bool)\\b",
+            "name": "entity.name.type.housify"
+        },
+        "const": {
+            "patterns": [
+                {
+                    "comment": "Any valid Housify identifier with const modifier",
+                    "match": "\\b(const)\\s+\\b([a-zA-Z][a-zA-Z0-9]*)\\b",
+                    "captures": {
+                        "1": {
+                            "name": "storage.modifier.housify"
+                        },
+                        "2": {
+                            "name": "variable.other.constant.housify"
+                        }
+                    }
+                }
+            ]
+        },
+        "variable": {
+            "patterns": [
+                {
+                    "comment": "Reserved language variables",
+                    "match": "\\b(global|player)\\b(?=\\.)",
+                    "captures": {
+                        "0": {
+                            "name": "variable.language.housify"
+                        },
+                        "1": {
+                            "name": "punctuation.dot.housify"
+                        }
+                    }
+                },
+                {
+                    "comment": "Any valid Housify identifier without const modifier",
+                    "match": "(?<!\\bconst\\s+)\\b([a-zA-Z][a-zA-Z0-9]*)\\b",
+                    "captures": {
+                        "0": {
+                            "name": "variable.other.housify"
+                        }
+                    }
+                }
+            ]
+        },
+        "handler": {
+            "comment": "Handler declaration",
+            "match": "\\b(handle)\\s*((?:[a-zA-Z][a-zA-Z0-9]*))\\s*({)",
+            "captures": {
+                "0": {
+                    "name": "keyword.other.function.housify"
+                },
+                "2": {
+                    "name": "entity.name.function.housify"
+                },
+                "3": {
+                    "name": "punctuation.brackets.curly.housify"
+                }
+            }
+        },
+        "house": {
+            "comment": "House declaration",
+            "match": "\\b(house)\\s*((?:[a-zA-Z][a-zA-Z0-9]*))\\s*({)",
+            "captures": {
+                "0": {
+                    "name": "keyword.other.struct.housify"
+                },
+                "2": {
+                    "name": "entity.name.type.housify"
+                },
+                "3": {
+                    "name": "punctuation.brackets.curly.housify"
+                }
+            }
+        }
+    }
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,36 @@
 import nextra from 'nextra';
+import fs from 'fs';
+import { getHighlighter, BUNDLED_LANGUAGES } from 'shiki';
+
+const housify = JSON.parse(
+    fs.readFileSync('./grammars/housify.tmLanguage.json'),
+    'utf8',
+);
+
+const rehypePrettyCodeOptions = {
+    getHighlighter: (options) =>
+        getHighlighter({
+            ...options,
+            langs: [
+                ...BUNDLED_LANGUAGES,
+                {
+                    id: 'Housify',
+                    scopeName: 'source.hsf',
+                    grammar: housify,
+                    aliases: ['hsf', 'housify'],
+                },
+            ],
+        }),
+};
 
 const withNextra = nextra({
     theme: 'nextra-theme-docs',
     themeConfig: './theme.config.jsx',
     latex: true,
     defaultShowCopyCode: true,
+    mdxOptions: {
+        rehypePrettyCodeOptions,
+    },
 });
 
 export default withNextra({

--- a/pages/examples/overview.mdx
+++ b/pages/examples/overview.mdx
@@ -6,7 +6,7 @@ This part of the documentation contains examples of Housify modules. These examp
 
 The Join Counter example demonstrates how to create a simple counter that increments every time a player joins the plot.
 
-```ts
+```hsf
 house Counter {
     global counter: int;
 
@@ -22,7 +22,7 @@ This example defines a house named `ExampleHouse` with a global stat `counter`. 
 
 The Simple Clicker Game example demonstrates how to create a simple clicker game where players can break blocks to increase their score.
 
-```ts
+```hsf
 house ClickerGame {
     player score: int;
 

--- a/pages/guide/quickstart.mdx
+++ b/pages/guide/quickstart.mdx
@@ -18,7 +18,7 @@ npm install -g housify
 
 Create a new file with the `.hsf` extension. This file will contain your Housify code. For example, you can create a file named `hello.hsf` with the following content:
 
-```ts
+```hsf
 house MyBeautifulHouse {
     global counter: int;
 

--- a/pages/language/conditions.mdx
+++ b/pages/language/conditions.mdx
@@ -2,7 +2,7 @@
 
 Conditions are used to check if a certain condition is met and execute some actions based on the result. They are defined using the `if` keyword followed by a condition and a block of code enclosed in curly braces. For example:
 
-```ts
+```hsf
 if (score > 100) {
     // Do something
 }
@@ -14,7 +14,7 @@ In this example, the code inside the block will only be executed if the conditio
 
 You can use `if`, `else if`, and `else` to create branching logic based on multiple conditions. For example:
 
-```ts
+```hsf
 if (score > 100) {
     // Do something
 } else if (score > 50) {

--- a/pages/language/handlers.mdx
+++ b/pages/language/handlers.mdx
@@ -2,7 +2,7 @@
 
 Event handlers are functions that respond to events triggered by players or the game. They are defined using the `handle` keyword followed by the event name and a block of code enclosed in curly braces. Event handlers must be placed after stat definitions. For example:
 
-```ts
+```hsf
 house MyHouse {
     global counter: int;
 

--- a/pages/language/stats.mdx
+++ b/pages/language/stats.mdx
@@ -19,7 +19,7 @@ Global stats are shared across all players in the plot. They are useful for stor
 
 Global stats are defined using the `global` keyword followed by the stat type and name. The initial value of a global stat is `0` by rules of the Housing. For example:
 
-```ts
+```hsf
 house MyHouse {
     global counter: int;
 }
@@ -33,7 +33,7 @@ Player stats are specific to each player in the plot. They are useful for storin
 
 Player stats are defined using the `player` keyword followed by the stat type and name. The initial value of a player stat is `0` by rules of the Housing. For example:
 
-```ts
+```hsf
 house MyHouse {
     player score: int;
 }

--- a/pages/language/structure.mdx
+++ b/pages/language/structure.mdx
@@ -6,7 +6,7 @@ Housify module is a collection of houses, each of which defines a set of stats a
 
 A house is a container for stats and event handlers. It is defined using the `house` keyword followed by the house name and a block of code enclosed in curly braces. For example:
 
-```ts
+```hsf
 house MyHouse {
     // Stats and event handlers go here
 }
@@ -18,7 +18,7 @@ Read more about [Stats](/language/stats).
 
 Stats are variables that store data associated with a house. They can be global or player-specific. Global stats are shared across all players, while player stats are specific to each player. Stats are defined using the `global` or `player` keyword followed by the stat type and name. Stat definitions must be placed before event handlers. For example:
 
-```ts
+```hsf
 house MyHouse {
     global counter: int;
     player score: int;
@@ -33,7 +33,7 @@ Read more about [Event Handlers](/language/handlers).
 
 Event handlers are functions that respond to events triggered by players or the game. They are defined using the `handle` keyword followed by the event name and a block of code enclosed in curly braces. Event handlers must be placed after stat definitions. For example:
 
-```ts
+```hsf
 house MyHouse {
     global counter: int;
 

--- a/pages/language/types.mdx
+++ b/pages/language/types.mdx
@@ -6,7 +6,7 @@ Housify supports a variety of types that can be used to define variables, consta
 
 Integers are numbers that can be positive or negative. They are defined using the `int` keyword. For example:
 
-```ts
+```hsf
 let x: int = 42;
 ```
 
@@ -16,7 +16,7 @@ In this example, a variable named `x` of type `int` is defined with an initial v
 
 Booleans are values that can be either `true` or `false`. They are defined using the `bool` keyword. For example:
 
-```ts
+```hsf
 let flag: bool = true;
 ```
 
@@ -26,7 +26,7 @@ In this example, a variable named `flag` of type `bool` is defined with an initi
 
 Structs are not allowed to be defined by user at the moment (but will be in the future). They are currently used internally to represent player and global stats. You can access struct fields using the `.` separator. For example:
 
-```ts
+```hsf
 let x: int = global.counter;
 ```
 

--- a/pages/language/variables.mdx
+++ b/pages/language/variables.mdx
@@ -2,7 +2,7 @@
 
 Variables are used to store temporary data. They are defined using the `let` keyword followed by the variable name, a type annotation, and an initial value. For example:
 
-```ts
+```hsf
 let x: int = 42;
 let flag: bool = true;
 ```
@@ -15,7 +15,7 @@ Read more about [Types](/language/types).
 
 Variables have a scope that determines where they can be accessed. If you define a variable inside a block of code, it can only be accessed within that block. For example:
 
-```ts
+```hsf
 if (true) {
     let x: int = 42;
 }
@@ -28,7 +28,7 @@ let x: bool = true;
 
 Constants are used to store immutable data. They are defined using the `const` keyword followed by the constant name, a type annotation, and an initial value. For example:
 
-```ts
+```hsf
 const MAX_SCORE: int = 100;
 ```
 


### PR DESCRIPTION
closes #4 

Mark code snippets with ` ```hsf `, ` ```housify ` or ` ```Housify ` annotation in order to apply proper syntax highlighting.

`Typescript` / `Housify` syntax highlighting
![image](https://github.com/user-attachments/assets/96d5c67c-bb03-450d-9092-d7327385a727)

e.g. `Material Theme Darker` applied:
![image](https://github.com/user-attachments/assets/249a9bcb-b39e-4938-8342-0bb8bbfb5108)
